### PR TITLE
Fix typo in success log message

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -333,7 +333,7 @@ def main(args):
         install_tailwind=params.tailwind,
         install_lucide=params.lucide,
     )
-    logger.info("💥 successfuly created %s", params.project_name)
+    logger.info("💥 successfully created %s", params.project_name)
 
     if params.deploy:
         setup_github_pages(params.project_name)


### PR DESCRIPTION
## Summary
- fix a spelling mistake in the success log message

## Testing
- `pip install requests --quiet`
- `python3 fuse.py --help`
- `python3 fuse.py --version`


------
https://chatgpt.com/codex/tasks/task_e_68405c038a9c83288e41f400d7c0d78a