### PR TITLE
Fix logger handler cleanup

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -71,8 +71,8 @@ def initialize_logs(
 ):
     """initializes logs"""
 
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
+    # Clear existing handlers to avoid duplicate logs when reinitializing
+    logger.handlers.clear()
 
     log_format = logging.Formatter(
         "%(asctime)-23s %(module)s.%(funcName)s %(levelname)-8s %(message)s"


### PR DESCRIPTION
## Summary
- call `logger.handlers.clear()` in `initialize_logs`

## Testing
- `python3 fuse.py --help`
- `python3 -m py_compile fuse.py`


------
https://chatgpt.com/codex/tasks/task_e_68420209a9908328980f55e99376e00f